### PR TITLE
Update to latest versions of Spring Boot and Dandelion Datatables

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ The simpliest application for show how to setup Dandelion-datatables when using 
 ## Technology Stack
 
  - Java 1.8
- - Spring Boot 1.2.4.RELEASE
+ - Spring Boot 1.3.3.RELEASE
  - Thymeleaf 2.1.4.RELEASE
- - Dandelion-Datatables 0.10.1
+ - datatables-thymeleaf 1.1.0
+ - dandelion-thymeleaf 1.1.1
+ - dandelion-core 1.1.1
  
 ## Running this sample
  Using __Maven__:

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.2.4.RELEASE</version>
+		<version>1.3.3.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -28,7 +28,17 @@
 		<dependency>
 			<groupId>com.github.dandelion</groupId>
 			<artifactId>datatables-thymeleaf</artifactId>
-			<version>0.10.1</version>
+			<version>1.1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.dandelion</groupId>
+			<artifactId>dandelion-thymeleaf</artifactId>
+			<version>1.1.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.dandelion</groupId>
+			<artifactId>dandelion-core</artifactId>
+			<version>1.1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Also updating dandelion-thymeleaf and dandelion-core to 1.1.1. This is
required in order to avoid a NullPointerException in
WebResourceScanner.java:167 that happens when using Spring Boot 1.3.3,
datatables-thymeleaf 1.1.0, dandelion-thymeleaf 1.1.0 and
dandelion-core 1.1.0
